### PR TITLE
Replace text logo with image in Navbar

### DIFF
--- a/frontend/src/components/layout/Navbar.jsx
+++ b/frontend/src/components/layout/Navbar.jsx
@@ -59,8 +59,12 @@ const Navbar = () => {
           {/* Logo */}
           <div className="flex items-center">
             <div className="flex-shrink-0">
-              <Link to="/" className="text-white text-xl font-medium hover:text-gray-300 transition-colors">
-                ImagePost
+              <Link to="/" className="flex items-center hover:opacity-80 transition-opacity">
+                <img 
+                  src="/icono.png" 
+                  alt="ImagePost Logo" 
+                  className="h-8 w-8"
+                />
               </Link>
             </div>
           </div>


### PR DESCRIPTION
Updated the Navbar component to display an image logo instead of the 'ImagePost' text. The logo now uses '/icono.png' with appropriate alt text and styling.