### PR TITLE
Expand error state container to full screen

### DIFF
--- a/frontend/src/components/PostDetail.jsx
+++ b/frontend/src/components/PostDetail.jsx
@@ -287,7 +287,7 @@ const PostDetail = () => {
 
   if (error || !post) {
     return (
-      <div className="flex flex-col items-center justify-center min-h-[60vh] text-center bg-black">
+      <div className="flex flex-col items-center justify-center min-h-screen w-full text-center bg-black">
         <h2 className="text-2xl font-medium text-white mb-2 tracking-widest">Post not found</h2>
         <p className="text-gray-500">{error || 'This post does not exist.'}</p>
         <button


### PR DESCRIPTION
Updated the error state container in PostDetail to use min-h-screen and w-full, ensuring the error message is centered and covers the entire viewport for better user experience.