### PR TITLE
Protect additional routes and redirect on logout

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -55,7 +55,14 @@ function App() {
                 </ProtectedRoute>
               } 
             />
-            <Route path="/search" element={<SearchPage />} />
+            <Route 
+              path="/search" 
+              element={
+                <ProtectedRoute>
+                  <SearchPage />
+                </ProtectedRoute>
+              } 
+            />
             <Route 
               path="/create-post" 
               element={
@@ -72,8 +79,22 @@ function App() {
                 </ProtectedRoute>
               } 
             />
-            <Route path="/tags/:tag" element={<TagPage />} />
-            <Route path="/explore" element={<Explore />} />
+            <Route 
+              path="/tags/:tag" 
+              element={
+                <ProtectedRoute>
+                  <TagPage />
+                </ProtectedRoute>
+              } 
+            />
+            <Route 
+              path="/explore" 
+              element={
+                <ProtectedRoute>
+                  <Explore />
+                </ProtectedRoute>
+              } 
+            />
             <Route path="*" element={<Navigate to="/" />} />
           </Routes>
         </div>

--- a/frontend/src/components/layout/Navbar.jsx
+++ b/frontend/src/components/layout/Navbar.jsx
@@ -2,12 +2,13 @@ import { useState, useRef, useEffect } from 'react';
 import { ChevronDown, Bell } from 'lucide-react';
 import { useAuth } from '../../contexts/AuthContext';
 import { useNotifications } from '../../contexts/NotificationContext';
-import { Link } from 'react-router-dom';
+import { Link, useNavigate } from 'react-router-dom';
 import NotificationDropdown from './NotificationDropdown';
 
 const Navbar = () => {
   const { user, logout } = useAuth();
   const { unreadCount, fetchUnreadCount } = useNotifications();
+  const navigate = useNavigate();
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const [isNotificationsOpen, setIsNotificationsOpen] = useState(false);
   const dropdownRef = useRef(null);
@@ -50,6 +51,7 @@ const Navbar = () => {
   const handleLogout = () => {
     logout();
     setIsDropdownOpen(false);
+    navigate('/login');
   };
 
   return (


### PR DESCRIPTION
Wrapped /search, /tags/:tag, and /explore routes with ProtectedRoute to restrict access to authenticated users. Updated Navbar logout handler to redirect users to the login page after logout.