### PR TITLE
Enable input while sending message

### DIFF
--- a/frontend/src/components/Messages/MessageInput.jsx
+++ b/frontend/src/components/Messages/MessageInput.jsx
@@ -72,7 +72,6 @@ const MessageInput = ({
             onChange={(e) => setNewMessage(e.target.value)}
             placeholder="Message..."
             className="w-full px-5 py-3 bg-neutral-900 border border-neutral-800 rounded-full text-white placeholder-gray-500 focus:outline-none focus:border-gray-600 focus:bg-neutral-800 transition-all duration-200 text-sm pr-24"
-            disabled={sendingMessage}
             maxLength={500}
           />
           {newMessage.trim() && (


### PR DESCRIPTION
Removed the disabled state from the message input field during message sending, allowing users to continue typing while a message is being sent.